### PR TITLE
Rust 2018 imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.1"
 authors = ["Ram Kaniyur <quadrupleslap@gmail.com>"]
 description = "Simple macros for generating ioctl numbers."
 license = "MIT"
-license_file = "LICENSE.md"
 repository = "https://github.com/quadrupleslap/ioctl-gen"
 documentation = "https://docs.rs/ioctl-gen"
 keywords = ["ioctl", "number", "encode", "control", "linux"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ```
 //! #[macro_use]
-//! extern crate ioctlify;
+//! extern crate ioctl_gen;
 //!
 //! # fn main() {
 //! // Taken from <linux/videodev2.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //! # fn main() {
 //! // Taken from <linux/videodev2.h>
-//! const VIDIOC_RESERVED:   u32 = io!(b'V', 1);
-//! const VIDIOC_STREAMON:   u32 = iow!(b'V', 18, 4);
+//! const VIDIOC_RESERVED: u32 = io!(b'V', 1);
+//! const VIDIOC_STREAMON: u32 = iow!(b'V', 18, 4);
 //! const VIDIOC_LOG_STATUS: u32 = io!(b'V', 70);
 //!
 //! assert_eq!(ioc_type!(VIDIOC_RESERVED), b'V' as u32);
@@ -61,11 +61,11 @@ pub const DIRSHIFT: u32 = SIZESHIFT + SIZEBITS;
 #[macro_export]
 macro_rules! ioc {
     ($dr:expr, $ty:expr, $nr:expr, $sz:expr) => {
-        (($dr as u32) << $crate::DIRSHIFT)  |
-        (($ty as u32) << $crate::TYPESHIFT) |
-        (($nr as u32) << $crate::NRSHIFT)   |
-        (($sz as u32) << $crate::SIZESHIFT)
-    }
+        (($dr as u32) << $crate::DIRSHIFT)
+            | (($ty as u32) << $crate::TYPESHIFT)
+            | (($nr as u32) << $crate::NRSHIFT)
+            | (($sz as u32) << $crate::SIZESHIFT)
+    };
 }
 
 /// Creates the ioctl number for an operation that isn't reading or writing.
@@ -73,7 +73,7 @@ macro_rules! ioc {
 macro_rules! io {
     ($ty:expr, $nr:expr) => {
         ioc!($crate::NONE, $ty, $nr, 0)
-    }
+    };
 }
 
 /// Creates the ioctl number for a read-only operation.
@@ -81,7 +81,7 @@ macro_rules! io {
 macro_rules! ior {
     ($ty:expr, $nr:expr, $sz:expr) => {
         ioc!($crate::READ, $ty, $nr, $sz)
-    }
+    };
 }
 
 /// Creates the ioctl number for a write-only operation.
@@ -89,7 +89,7 @@ macro_rules! ior {
 macro_rules! iow {
     ($ty:expr, $nr:expr, $sz:expr) => {
         ioc!($crate::WRITE, $ty, $nr, $sz)
-    }
+    };
 }
 
 /// Creates the ioctl number for a read/write operation.
@@ -97,30 +97,37 @@ macro_rules! iow {
 macro_rules! iowr {
     ($ty:expr, $nr:expr, $sz:expr) => {
         ioc!($crate::READ | $crate::WRITE, $ty, $nr, $sz)
-    }
+    };
 }
 
 /// Decodes the access mode / direction from an ioctl number.
 #[macro_export]
 macro_rules! ioc_dir {
-    ($n:expr) => { ($n >> $crate::DIRSHIFT) & $crate::DIRMASK }
+    ($n:expr) => {
+        ($n >> $crate::DIRSHIFT) & $crate::DIRMASK
+    };
 }
 
 /// Decodes the type from an ioctl number.
 #[macro_export]
 macro_rules! ioc_type {
-    ($n:expr) => { ($n >> $crate::TYPESHIFT) & $crate::TYPEMASK }
+    ($n:expr) => {
+        ($n >> $crate::TYPESHIFT) & $crate::TYPEMASK
+    };
 }
 
 /// Decodes the function number from an ioctl number.
 #[macro_export]
 macro_rules! ioc_nr {
-    ($n:expr) => { ($n >> $crate::NRSHIFT) & $crate::NRMASK }
+    ($n:expr) => {
+        ($n >> $crate::NRSHIFT) & $crate::NRMASK
+    };
 }
 
 /// Decodes the parameter size from an ioctl number.
 #[macro_export]
 macro_rules! ioc_size {
-    ($n:expr) => { ($n >> $crate::SIZESHIFT) & $crate::SIZEMASK }
+    ($n:expr) => {
+        ($n >> $crate::SIZESHIFT) & $crate::SIZEMASK
+    };
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,9 @@
 //!
 //! Here are some examples:
 //!
-//! ```
-//! #[macro_use]
-//! extern crate ioctl_gen;
+//! ```edition2018
+//! use ioctl_gen::{io, iow, ioc_type, ioc_nr};
 //!
-//! # fn main() {
 //! // Taken from <linux/videodev2.h>
 //! const VIDIOC_RESERVED: u32 = io!(b'V', 1);
 //! const VIDIOC_STREAMON: u32 = iow!(b'V', 18, 4);
@@ -16,7 +14,6 @@
 //! assert_eq!(ioc_type!(VIDIOC_RESERVED), b'V' as u32);
 //! assert_eq!(VIDIOC_STREAMON, 1074026002);
 //! assert_eq!(ioc_nr!(VIDIOC_LOG_STATUS), 70);
-//! # }
 //! ```
 
 //TODO: Nonstandard platforms.
@@ -72,7 +69,7 @@ macro_rules! ioc {
 #[macro_export]
 macro_rules! io {
     ($ty:expr, $nr:expr) => {
-        ioc!($crate::NONE, $ty, $nr, 0)
+        $crate::ioc!($crate::NONE, $ty, $nr, 0)
     };
 }
 
@@ -80,7 +77,7 @@ macro_rules! io {
 #[macro_export]
 macro_rules! ior {
     ($ty:expr, $nr:expr, $sz:expr) => {
-        ioc!($crate::READ, $ty, $nr, $sz)
+        $crate::ioc!($crate::READ, $ty, $nr, $sz)
     };
 }
 
@@ -88,7 +85,7 @@ macro_rules! ior {
 #[macro_export]
 macro_rules! iow {
     ($ty:expr, $nr:expr, $sz:expr) => {
-        ioc!($crate::WRITE, $ty, $nr, $sz)
+        $crate::ioc!($crate::WRITE, $ty, $nr, $sz)
     };
 }
 
@@ -96,7 +93,7 @@ macro_rules! iow {
 #[macro_export]
 macro_rules! iowr {
     ($ty:expr, $nr:expr, $sz:expr) => {
-        ioc!($crate::READ | $crate::WRITE, $ty, $nr, $sz)
+        $crate::ioc!($crate::READ | $crate::WRITE, $ty, $nr, $sz)
     };
 }
 


### PR DESCRIPTION
The main point of this PR is to enable Rust 2018 edition-style imports of this library. So macros can be imported e.g. as

    use ioctl_gen::io;

instead of using

    #[macro_use]
    extern crate ioctl_gen;

I dared to bundle several unrelated commits in this PR as they are all very small. If you wan to have separate PRs, please let me know and I'll do that.